### PR TITLE
[#103] 엑세스 토큰 리프레시 API 구현

### DIFF
--- a/src/main/java/com/plogcareers/backend/blog/domain/dto/RefreshAccessTokenResponse.java
+++ b/src/main/java/com/plogcareers/backend/blog/domain/dto/RefreshAccessTokenResponse.java
@@ -1,0 +1,14 @@
+package com.plogcareers.backend.blog.domain.dto;
+
+import com.plogcareers.backend.ums.domain.dto.Token;
+import lombok.*;
+
+@Getter
+@Builder
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+public class RefreshAccessTokenResponse {
+    public Token token;
+}

--- a/src/main/java/com/plogcareers/backend/ums/controller/AuthController.java
+++ b/src/main/java/com/plogcareers/backend/ums/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.plogcareers.backend.ums.controller;
 
+import com.plogcareers.backend.blog.domain.dto.RefreshAccessTokenResponse;
 import com.plogcareers.backend.common.domain.dto.ErrorResponse;
 import com.plogcareers.backend.common.domain.dto.SDataResponse;
 import com.plogcareers.backend.common.domain.dto.SResponse;
@@ -7,7 +8,10 @@ import com.plogcareers.backend.common.exception.InvalidParamException;
 import com.plogcareers.backend.ums.constant.Auth;
 import com.plogcareers.backend.ums.domain.dto.*;
 import com.plogcareers.backend.ums.service.AuthService;
-import io.swagger.annotations.*;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -128,8 +132,8 @@ public class AuthController {
 
     @PutMapping("/edit-profile")
     public ResponseEntity<SResponse> updateUserProfile(@ApiIgnore @RequestHeader(name = Auth.token) String token,
-                                                @Valid @RequestBody UpdateUserProfileRequest request,
-                                                BindingResult result) {
+                                                       @Valid @RequestBody UpdateUserProfileRequest request,
+                                                       BindingResult result) {
         if (result.hasErrors()) {
             throw new InvalidParamException(result);
         }
@@ -147,8 +151,8 @@ public class AuthController {
 
     @PutMapping("/edit-password")
     public ResponseEntity<SResponse> updateUserPassword(@ApiIgnore @RequestHeader(name = Auth.token) String token,
-                                                @Valid @RequestBody UpdateUserPasswordRequest request,
-                                                BindingResult result) {
+                                                        @Valid @RequestBody UpdateUserPasswordRequest request,
+                                                        BindingResult result) {
         if (result.hasErrors()) {
             throw new InvalidParamException(result);
         }
@@ -166,9 +170,21 @@ public class AuthController {
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @PostMapping("/exit-user")
     public ResponseEntity<SResponse> exitUser(@ApiIgnore @RequestHeader(name = Auth.token) String token,
-                                                @Valid @RequestBody ExitUserRequest request) {
+                                              @Valid @RequestBody ExitUserRequest request) {
         Long loginedUserID = authService.getLoginedUserID(token);
         authService.exitUser(loginedUserID, request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @ApiOperation(value = "엑세스 토큰 리프레시")
+    @ApiResponses(value = {
+            @ApiResponse(code = 200, message = "정상 리프레시 시"),
+            @ApiResponse(code = 401, message = "잘못된 사용자 요청", response = ErrorResponse.class)
+    })
+    @PostMapping("/refresh-access-token")
+    public ResponseEntity<SResponse> refreshToken(@ApiIgnore @RequestHeader(name = Auth.token) String token) {
+        Long loginedUserID = authService.getLoginedUserID(token);
+        RefreshAccessTokenResponse newToken = authService.refreshAccessToken(loginedUserID);
+        return ResponseEntity.status(HttpStatus.OK).body(new SDataResponse<>(newToken));
     }
 }

--- a/src/main/java/com/plogcareers/backend/ums/domain/dto/Token.java
+++ b/src/main/java/com/plogcareers/backend/ums/domain/dto/Token.java
@@ -2,10 +2,12 @@ package com.plogcareers.backend.ums.domain.dto;
 
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @AllArgsConstructor
 @Getter
+@EqualsAndHashCode
 public class Token {
     @ApiModelProperty(value = "로그인 엑세스 토큰")
     private String accessToken;

--- a/src/main/java/com/plogcareers/backend/ums/service/AuthService.java
+++ b/src/main/java/com/plogcareers/backend/ums/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.plogcareers.backend.ums.service;
 
+import com.plogcareers.backend.blog.domain.dto.RefreshAccessTokenResponse;
 import com.plogcareers.backend.blog.domain.entity.Blog;
 import com.plogcareers.backend.blog.exception.BlogNotFoundException;
 import com.plogcareers.backend.blog.repository.BlogRepository;
@@ -81,6 +82,18 @@ public class AuthService {
         }
 
         return UserLoginResponse.builder()
+                .token(new Token(jwtTokenProvider.createToken(user.getUsername(), user, blogs.get(0).getId())))
+                .build();
+    }
+
+    public RefreshAccessTokenResponse refreshAccessToken(Long loginedUserID) {
+        User user = userRepository.findById(loginedUserID).orElseThrow(UserNotFoundException::new);
+        List<Blog> blogs = blogRepository.findByUser(user);
+        if (blogs.isEmpty()) {
+            throw new BlogNotFoundException();
+        }
+
+        return RefreshAccessTokenResponse.builder()
                 .token(new Token(jwtTokenProvider.createToken(user.getUsername(), user, blogs.get(0).getId())))
                 .build();
     }
@@ -220,7 +233,7 @@ public class AuthService {
         userRepository.save(request.toUserEntity(user));
     }
 
-    public void updateUserPassword(Long loginedUserID, UpdateUserPasswordRequest request){
+    public void updateUserPassword(Long loginedUserID, UpdateUserPasswordRequest request) {
         User user = userRepository.findById(request.getUserID()).orElseThrow(UserNotFoundException::new);
         if (!loginedUserID.equals(user.getId())) {
             throw new NotProperAuthorityException();

--- a/src/test/java/com/plogcareers/backend/ums/service/AuthServiceTest.java
+++ b/src/test/java/com/plogcareers/backend/ums/service/AuthServiceTest.java
@@ -1,6 +1,11 @@
 package com.plogcareers.backend.ums.service;
 
+import com.plogcareers.backend.blog.domain.dto.RefreshAccessTokenResponse;
+import com.plogcareers.backend.blog.domain.entity.Blog;
+import com.plogcareers.backend.blog.exception.BlogNotFoundException;
+import com.plogcareers.backend.blog.repository.BlogRepository;
 import com.plogcareers.backend.ums.domain.dto.ExitUserRequest;
+import com.plogcareers.backend.ums.domain.dto.Token;
 import com.plogcareers.backend.ums.domain.dto.UpdateUserPasswordRequest;
 import com.plogcareers.backend.ums.domain.dto.UpdateUserProfileRequest;
 import com.plogcareers.backend.ums.domain.entity.User;
@@ -8,6 +13,7 @@ import com.plogcareers.backend.ums.exception.IncorrectPasswordException;
 import com.plogcareers.backend.ums.exception.NotProperAuthorityException;
 import com.plogcareers.backend.ums.exception.UserNotFoundException;
 import com.plogcareers.backend.ums.repository.UserRepository;
+import com.plogcareers.backend.ums.security.JwtTokenProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.mockito.Mockito.*;
@@ -27,14 +34,19 @@ public class AuthServiceTest {
     UserRepository userRepository;
 
     @Mock
+    BlogRepository blogRepository;
+    @Mock
     PasswordEncoder passwordEncoder;
+
+    @Mock
+    JwtTokenProvider jwtTokenProvider;
 
     @InjectMocks
     AuthService authService;
 
     @Test
     @DisplayName("updateUserProfile - 유저가 없는 경우 테스트")
-    void testUpdateUserProfile_1(){
+    void testUpdateUserProfile_1() {
         // given
         when(
                 userRepository.findById(-1L)
@@ -45,7 +57,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("updateUserProfile - 로그인한 유저와 요청 유저가 다른 경우 테스트")
-    void testUpdateUserProfile_2(){
+    void testUpdateUserProfile_2() {
         // given
         when(
                 userRepository.findById(1L)
@@ -58,7 +70,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("updateUserProfile - 정상동작")
-    void testUpdateUserProfile_3(){
+    void testUpdateUserProfile_3() {
         // given
         when(
                 userRepository.findById(1L)
@@ -73,7 +85,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("updateUserPassword - 유저가 없는 경우 테스트")
-    void testUpdateUserPassword_1(){
+    void testUpdateUserPassword_1() {
         // given
         when(
                 userRepository.findById(-1L)
@@ -84,7 +96,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("updateUserPassword - 로그인한 유저와 요청 유저가 다른 경우 테스트")
-    void testUpdateUserPassword_2(){
+    void testUpdateUserPassword_2() {
         // given
         when(
                 userRepository.findById(1L)
@@ -97,7 +109,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("updateUserPassword - 현재 패스워드가 다른 경우 테스트")
-    void testUpdateUserPassword_3(){
+    void testUpdateUserPassword_3() {
         // given
         when(
                 passwordEncoder.matches("2", "1")
@@ -113,7 +125,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("updateUserPassword - 정상동작")
-    void testUpdateUserPassword_4(){
+    void testUpdateUserPassword_4() {
         // given
         when(
                 passwordEncoder.matches("1", "1")
@@ -131,7 +143,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("exitUser - 유저가 없는 경우 테스트")
-    void testExitUser_1(){
+    void testExitUser_1() {
         // given
         when(
                 userRepository.findById(-1L)
@@ -142,7 +154,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("exitUser - 로그인한 유저와 요청 유저가 다른 경우 테스트")
-    void testExitUser_2(){
+    void testExitUser_2() {
         // given
         when(
                 userRepository.findById(2L)
@@ -155,7 +167,7 @@ public class AuthServiceTest {
 
     @Test
     @DisplayName("exitUser - 정상동작")
-    void testExitUser_3(){
+    void testExitUser_3() {
         // given
         when(
                 userRepository.findById(1L)
@@ -166,5 +178,51 @@ public class AuthServiceTest {
         authService.exitUser(1L, ExitUserRequest.builder().userID(1L).build());
         // then
         verify(userRepository, times(1)).delete(any());
+    }
+
+    @Test
+    @DisplayName("refreshAccessToken - 없는 유저의 경우 에러")
+    void testRefreshAccessToken_1() {
+        when(
+                userRepository.findById(100L)
+        ).thenReturn(Optional.empty());
+
+        Assertions.assertThrows(UserNotFoundException.class, () -> authService.refreshAccessToken(100L));
+    }
+
+    @Test
+    @DisplayName("refreshAccessToken - 유저의 블로그가 없는 경우 에러")
+    void testRefreshAccessToken_2() {
+        User testUser = User.builder().id(100L).build();
+        when(
+                userRepository.findById(100L)
+        ).thenReturn(Optional.of(testUser));
+        when(
+                blogRepository.findByUser(testUser)
+        ).thenReturn(List.of());
+
+        Assertions.assertThrows(BlogNotFoundException.class, () -> authService.refreshAccessToken(100L));
+    }
+
+    @Test
+    @DisplayName("refreshAccessToken - 정상동작")
+    void testRefreshAccessToken_3() {
+        User testUser = User.builder().id(100L).build();
+        Blog testBlog = Blog.builder().id(100L).user(testUser).build();
+        when(
+                userRepository.findById(100L)
+        ).thenReturn(Optional.of(testUser));
+        when(
+                blogRepository.findByUser(testUser)
+        ).thenReturn(List.of(testBlog));
+        when(
+                jwtTokenProvider.createToken(testUser.getUsername(), testUser, testBlog.getId())
+        ).thenReturn("testToken");
+
+        Assertions.assertEquals(
+                RefreshAccessTokenResponse
+                        .builder()
+                        .token(new Token("testToken"))
+                        .build(), authService.refreshAccessToken(100L));
     }
 }


### PR DESCRIPTION
resolved: #103 

# 설명
- 엑세스 토큰을 리프레시 하는 함수를 구현하였습니다.
- 기존에 잘못 구현되어있던 로그인 부분을 수정하였습니다. (토큰이 invalid 시 500을 떨구는 버그)