### PR TITLE
[#127] 회원 정보 조회 api에 introMd도 조회할 수 있도록 수정, 블로그 단건 조회 api 변수명 통일

### DIFF
--- a/src/main/java/com/plogcareers/backend/blog/domain/dto/GetBlogResponse.java
+++ b/src/main/java/com/plogcareers/backend/blog/domain/dto/GetBlogResponse.java
@@ -18,5 +18,5 @@ public class GetBlogResponse {
     @ApiModelProperty(value = "블로그 짧은 소개글")
     private String shortIntro;
     @ApiModelProperty(value = "블로그 소개 HTML")
-    private String introHtml;
+    private String introHTML;
 }

--- a/src/main/java/com/plogcareers/backend/blog/domain/entity/Blog.java
+++ b/src/main/java/com/plogcareers/backend/blog/domain/entity/Blog.java
@@ -63,7 +63,7 @@ public class Blog {
                 .blogName(this.blogName)
                 .blogUser(this.user.toBlogUserDTO())
                 .shortIntro(this.shortIntro)
-                .introHtml(this.introHTML)
+                .introHTML(this.introHTML)
                 .build();
     }
 }

--- a/src/main/java/com/plogcareers/backend/ums/domain/dto/GetUserResponse.java
+++ b/src/main/java/com/plogcareers/backend/ums/domain/dto/GetUserResponse.java
@@ -27,4 +27,7 @@ public class GetUserResponse {
 
     @ApiModelProperty(value = "블로그 소개 HTML")
     private String introHTML;
+
+    @ApiModelProperty(value = "블로그 소개 Md")
+    private String introMd;
 }

--- a/src/main/java/com/plogcareers/backend/ums/domain/entity/User.java
+++ b/src/main/java/com/plogcareers/backend/ums/domain/entity/User.java
@@ -129,6 +129,7 @@ public class User implements UserDetails {
                 .blogName(blog.getBlogName())
                 .shortIntro(blog.getShortIntro())
                 .introHTML(blog.getIntroHTML())
+                .introMd(blog.getIntroMd())
                 .build();
     }
 

--- a/src/test/java/com/plogcareers/backend/ums/service/UserServiceTest.java
+++ b/src/test/java/com/plogcareers/backend/ums/service/UserServiceTest.java
@@ -64,7 +64,8 @@ public class UserServiceTest {
                 List.of(Blog.builder()
                         .blogName("blogName")
                         .shortIntro("shortIntro")
-                        .introHTML("introHtml")
+                        .introHTML("introHTML")
+                        .introMd("introMd")
                         .build())
         );
         // when
@@ -76,7 +77,8 @@ public class UserServiceTest {
                                                     .profileImageURL("profileImageUrl")
                                                     .blogName("blogName")
                                                     .shortIntro("shortIntro")
-                                                    .introHTML("introHtml")
+                                                    .introHTML("introHTML")
+                                                    .introMd("introMd")
                                                     .build();
         // then
         Assertions.assertEquals(got, want);


### PR DESCRIPTION
resolved: #127

# 설명

회원 정보 조회 api에 introMd도 조회할 수 있도록 response에 추가하였습니다.
블로그 단건 조회 api에서 response의 변수명을 컨벤션에 맞게 수정하였습니다. (Html -> HTML)
