### PR TITLE
[#129] 카테고리 수정 API변경 및 API 정리

### DIFF
--- a/src/main/java/com/plogcareers/backend/blog/controller/BlogController.java
+++ b/src/main/java/com/plogcareers/backend/blog/controller/BlogController.java
@@ -3,6 +3,7 @@ package com.plogcareers.backend.blog.controller;
 import com.plogcareers.backend.blog.domain.dto.*;
 import com.plogcareers.backend.blog.domain.validator.PatchBlogRequestValidator;
 import com.plogcareers.backend.blog.exception.BlogNotFoundException;
+import com.plogcareers.backend.blog.exception.CategoryDuplicatedException;
 import com.plogcareers.backend.blog.exception.PostingNotFoundException;
 import com.plogcareers.backend.blog.exception.TagNotFoundException;
 import com.plogcareers.backend.blog.service.BlogService;
@@ -42,12 +43,11 @@ public class BlogController {
             @ApiResponse(code = 201, message = "정상 동작 시"),
             @ApiResponse(code = 404, message = "태그 없음", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "서버 에러", response = ErrorResponse.class)
-    }
-    )
+    })
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("/{blogID}/postings")
     public ResponseEntity<SResponse> createPosting(@ApiParam(name = "blogID", value = "블로그 ID", required = true) @PathVariable Long blogID,
-                                                   @ApiIgnore @RequestHeader(name = Auth.token) String token,
+                                                   @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                    @Valid @RequestBody CreatePostingRequest request,
                                                    BindingResult result) throws TagNotFoundException {
         if (result.hasErrors()) {
@@ -70,7 +70,7 @@ public class BlogController {
     @LogExecutionTime
     public ResponseEntity<SResponse> getPosting(@ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID,
                                                 @ApiParam(name = "postingID", value = "포스팅 ID") @PathVariable Long postingID,
-                                                @ApiIgnore @RequestHeader(name = Auth.token, required = false) String token) throws UserNotFoundException {
+                                                @ApiIgnore @RequestHeader(name = Auth.TOKEN, required = false) String token) throws UserNotFoundException {
         Long loginedUserID = authService.getLoginedUserID(token);
         return ResponseEntity.status(HttpStatus.OK).body(new SDataResponse<>(postingService.getPosting(blogID, postingID, loginedUserID)));
 
@@ -85,7 +85,7 @@ public class BlogController {
     })
     @GetMapping("/{blogID}/postings")
     public ResponseEntity<SResponse> listPostings(@ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID,
-                                                  @ApiIgnore @RequestHeader(name = Auth.token, required = false) String token,
+                                                  @ApiIgnore @RequestHeader(name = Auth.TOKEN, required = false) String token,
                                                   @Valid ListPostingsRequest request,
                                                   BindingResult result) {
         if (result.hasErrors()) {
@@ -102,10 +102,9 @@ public class BlogController {
             @ApiResponse(code = 401, message = "수정할 권한이 없음", response = ErrorResponse.class),
             @ApiResponse(code = 404, message = "포스팅이 없거나, 블로그가 없거나, 유저 정보가 없음", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "서버 에러")
-    }
-    )
+    })
     @PutMapping("/{blogID}/postings/{postingID}")
-    public ResponseEntity<SResponse> updatePosting(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> updatePosting(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                    @PathVariable Long blogID,
                                                    @PathVariable Long postingID,
                                                    @Valid @RequestBody UpdatePostingRequest request,
@@ -123,12 +122,11 @@ public class BlogController {
             @ApiResponse(code = 204, message = "정삭 삭제"),
             @ApiResponse(code = 404, message = "포스팅 없음"),
             @ApiResponse(code = 500, message = "서버 에러")
-    }
-    )
+    })
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @DeleteMapping("/{blogID}/postings/{postingID}")
     public ResponseEntity<SResponse> deletePosting(@PathVariable Long blogID, @PathVariable Long postingID,
-                                                   @ApiIgnore @RequestHeader(name = Auth.token) String token) {
+                                                   @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token) {
         Long userID = authService.getLoginedUserID(token);
         postingService.deletePosting(blogID, postingID, userID);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
@@ -167,7 +165,7 @@ public class BlogController {
     )
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("/{blogID}/categories")
-    public ResponseEntity<SResponse> createCategory(@PathVariable Long blogID, @ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> createCategory(@PathVariable Long blogID, @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                     @Valid @RequestBody CreateCategoryRequest categoryRequest) throws UserNotFoundException {
         Long loginedUserID = authService.getLoginedUserID(token);
         blogService.createCategory(blogID, loginedUserID, categoryRequest);
@@ -180,34 +178,39 @@ public class BlogController {
             @ApiResponse(code = 299, message = "정상 조회(outer)", response = SDataResponse.class),
             @ApiResponse(code = 404, message = "블로그 없음"),
             @ApiResponse(code = 500, message = "서버 에러")
-    }
-    )
+    })
     @GetMapping("/{blogID}/categories")
     public ResponseEntity<SResponse> listCategories(@ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID) {
         return ResponseEntity.status(HttpStatus.OK).body(new SDataResponse<>(blogService.listCategories(blogID)));
 
     }
 
-    @ApiOperation(value = "Category 리스트 변경")
+    @ApiOperation(value = "Category 부분 수정")
     @ApiResponses(value = {
-            @ApiResponse(code = 200, message = "정상 수정(data)", response = ListCategoriesResponse.class),
-            @ApiResponse(code = 299, message = "정상 수정(outer)", response = SDataResponse.class),
-            @ApiResponse(code = 404, message = "블로그 없음"),
+            @ApiResponse(code = 204, message = "정상 수정"),
+            @ApiResponse(code = 404, message = "자원이 없음 세부 메시지는 코드 및 메시지 참조", response = ErrorResponse.class),
+            @ApiResponse(code = 400, message = "잘못된 파라미터 요청", response = ErrorResponse.class),
+            @ApiResponse(code = 409, message = "카테고리 중복", response = ErrorResponse.class),
             @ApiResponse(code = 500, message = "서버 에러")
-    }
-    )
-    @PutMapping("/{blogID}/categories/{categoryID}")
-    public ResponseEntity<SResponse> updateCategory(@ApiIgnore @RequestHeader(name = Auth.token) String token,
-                                                    @ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID,
-                                                    @ApiParam(name = "categoryID", value = "카테고리 ID") @PathVariable Long categoryID,
-                                                    @Valid @RequestBody UpdateCategoryRequest request,
-                                                    BindingResult result) throws BlogNotFoundException, UserNotFoundException {
+    })
+    @PatchMapping("/{blogID}/categories/{categoryID}")
+    public ResponseEntity<SResponse> patchCategory(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
+                                                   @ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID,
+                                                   @ApiParam(name = "categoryID", value = "카테고리 ID") @PathVariable Long categoryID,
+                                                   @Valid @RequestBody UpdateCategoryRequest request,
+                                                   BindingResult result) throws BlogNotFoundException, UserNotFoundException, CategoryDuplicatedException {
         if (result.hasErrors()) {
             throw new InvalidParamException(result);
         }
-        Long loginedUserID = authService.getLoginedUserID(token);
-        blogService.updateCategory(blogID, loginedUserID, request);
-        return ResponseEntity.status(HttpStatus.OK).build();
+
+        // path variable을 request에 주입
+        request.setBlogID(blogID);
+        request.setCategoryID(categoryID);
+        request.setLoginedUserID(authService.getLoginedUserID(token));
+
+        blogService.patchCategory(request);
+
+        return ResponseEntity.noContent().build();
     }
 
     @ApiOperation(value = "Category 삭제")
@@ -215,14 +218,14 @@ public class BlogController {
             @ApiResponse(code = 204, message = "정삭 삭제"),
             @ApiResponse(code = 404, message = "블로그 없음"),
             @ApiResponse(code = 500, message = "서버 에러")
-    }
-    )
+    })
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @DeleteMapping("/{blogID}/categories/{categoryID}")
-    public ResponseEntity<SResponse> deleteCategory(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> deleteCategory(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                     @ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID,
                                                     @ApiParam(name = "categoryID", value = "카테고리 ID") @PathVariable Long categoryID) throws UserNotFoundException {
         Long loginedUserID = authService.getLoginedUserID(token);
+
         blogService.deleteCategory(blogID, categoryID, loginedUserID);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
@@ -234,12 +237,12 @@ public class BlogController {
             @ApiResponse(code = 299, message = "정상조회 (outer)", response = SDataResponse.class),
             @ApiResponse(code = 400, message = "잘못된 유저 요청", response = ErrorResponse.class),
             @ApiResponse(code = 404, message = "해당하는 포스팅 ID를 가진 포스팅 없음", response = ErrorResponse.class),
-            @ApiResponse(code = 500, message = "서버 에러", response = ErrorResponse.class)}
-    )
+            @ApiResponse(code = 500, message = "서버 에러", response = ErrorResponse.class)
+    })
     @GetMapping("/{blogID}/postings/{postingID}/comments")
-    public ResponseEntity<SResponse> listComments(@ApiIgnore @RequestHeader(name = Auth.token, required = false) String token,
-                                                  @ApiParam(name = "blogID", value = "블로그 ID", required = true) @PathVariable Long blogID,
-                                                  @ApiParam(name = "postingID", value = "포스팅 ID", required = true) @PathVariable Long postingID) throws UserNotFoundException {
+    public ResponseEntity<SResponse> listComments(@ApiIgnore @RequestHeader(name = Auth.TOKEN, required = false) String token,
+                                                  @ApiParam(name = "blogID", value = "블로그 ID", required = true, example = "1") @PathVariable Long blogID,
+                                                  @ApiParam(name = "postingID", value = "포스팅 ID", required = true, example = "1") @PathVariable Long postingID) throws UserNotFoundException {
         Long loginedUserID = authService.getLoginedUserID(token);
         return ResponseEntity.status(HttpStatus.OK).body(new SDataResponse<>(postingService.listComments(blogID, postingID, loginedUserID)));
     }
@@ -253,7 +256,7 @@ public class BlogController {
             }
     )
     @PostMapping("/{blogID}/postings/{postingID}/comment")
-    public ResponseEntity<SResponse> createComment(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> createComment(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                    @ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID,
                                                    @ApiParam(name = "postingID", value = "포스팅 ID") @PathVariable Long postingID,
                                                    @Valid @RequestBody CreateCommentRequest request,
@@ -267,16 +270,14 @@ public class BlogController {
     }
 
     @ApiOperation(value = "포스팅 덧글 수정")
-    @ApiResponses(
-            value = {
-                    @ApiResponse(code = 204, message = "정상 수정"),
-                    @ApiResponse(code = 400, message = "잘못된 파라미터 요청", response = ErrorResponse.class),
-                    @ApiResponse(code = 401, message = "수정할 권한이 없음", response = ErrorResponse.class),
-                    @ApiResponse(code = 404, message = "포스팅이 없거나, 덧글이 없거나, 유저 정보가 없음", response = ErrorResponse.class),
-            }
-    )
+    @ApiResponses(value = {
+            @ApiResponse(code = 204, message = "정상 수정"),
+            @ApiResponse(code = 400, message = "잘못된 파라미터 요청", response = ErrorResponse.class),
+            @ApiResponse(code = 401, message = "수정할 권한이 없음", response = ErrorResponse.class),
+            @ApiResponse(code = 404, message = "포스팅이 없거나, 덧글이 없거나, 유저 정보가 없음", response = ErrorResponse.class),
+    })
     @PutMapping("/{blogID}/postings/{postingID}/comments/{commentID}")
-    public ResponseEntity<SResponse> updateComment(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> updateComment(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                    @ApiParam(name = "blogID", value = "블로그 ID", required = true) @PathVariable Long blogID,
                                                    @ApiParam(name = "postingID", value = "포스팅 ID", required = true) @PathVariable Long postingID,
                                                    @ApiParam(name = "commentID", value = "덧글 ID", required = true) @PathVariable Long commentID,
@@ -297,7 +298,7 @@ public class BlogController {
             @ApiResponse(code = 404, message = "포스팅이 없거나, 덧글이 없거나, 유저장보가 없음", response = ErrorResponse.class),
     })
     @DeleteMapping("/{blogID}/postings/{postingID}/comments/{commentID}")
-    public ResponseEntity<SResponse> deleteComment(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> deleteComment(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                    @ApiParam(name = "blogID", value = "블로그 ID", required = true) @PathVariable Long blogID,
                                                    @ApiParam(name = "postingID", value = "포스팅 ID", required = true) @PathVariable Long postingID,
                                                    @ApiParam(name = "commentID", value = "덧글 ID", required = true) @PathVariable Long commentID) {
@@ -328,7 +329,7 @@ public class BlogController {
     @PostMapping("/{blogID}/postings/{postingID}/star")
     public ResponseEntity<SResponse> createPostingStar(@ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID,
                                                        @ApiParam(name = "postingID", value = "포스팅 ID") @PathVariable Long postingID,
-                                                       @ApiIgnore @RequestHeader(name = Auth.token) String token) {
+                                                       @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token) {
         Long loginedUserID = authService.getLoginedUserID(token);
         postingService.createPostingStar(blogID, postingID, loginedUserID);
         return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -343,7 +344,7 @@ public class BlogController {
     @DeleteMapping("/{blogID}/postings/{postingID}/star")
     public ResponseEntity<SResponse> deletePostingStar(@ApiParam(name = "blogID", value = "블로그 ID") @PathVariable Long blogID,
                                                        @ApiParam(name = "postingID", value = "포스팅 ID") @PathVariable Long postingID,
-                                                       @ApiIgnore @RequestHeader(name = Auth.token) String token) {
+                                                       @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token) {
 
         Long loginedUserID = authService.getLoginedUserID(token);
         postingService.deletePostingStar(blogID, postingID, loginedUserID);
@@ -369,7 +370,7 @@ public class BlogController {
     })
     @PostMapping("/{blogID}/tags")
     public ResponseEntity<SResponse> createTag(@PathVariable Long blogID,
-                                               @ApiIgnore @RequestHeader(name = Auth.token) String token,
+                                               @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                @Valid @RequestBody CreateTagRequest request,
                                                BindingResult result) {
         if (result.hasErrors()) {
@@ -393,7 +394,7 @@ public class BlogController {
     @PutMapping("/{blogID}/tags/{tagID}")
     public ResponseEntity<SResponse> updateTag(@PathVariable Long blogID,
                                                @PathVariable Long tagID,
-                                               @ApiIgnore @RequestHeader(name = Auth.token) String token,
+                                               @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                @Valid @RequestBody UpdateTagRequest request,
                                                BindingResult result) {
         if (result.hasErrors()) {
@@ -413,7 +414,7 @@ public class BlogController {
     @DeleteMapping("/{blogID}/tags/{tagID}")
     public ResponseEntity<SResponse> deleteTag(@ApiParam(value = "삭제하고자 하는 태그가 속해 있는 블로그 ID", example = "1") @PathVariable Long blogID,
                                                @ApiParam(value = "삭제하고자 하는 태그 ID", example = "10") @PathVariable Long tagID,
-                                               @ApiIgnore @RequestHeader(name = Auth.token) String token) {
+                                               @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token) {
         Long loginedUserID = authService.getLoginedUserID(token);
         blogService.deleteTag(blogID, tagID, loginedUserID);
         return ResponseEntity.noContent().build();
@@ -450,10 +451,10 @@ public class BlogController {
             @ApiResponse(code = 401, message = "잘못된 사용자 요청", response = ErrorResponse.class),
     })
     @PatchMapping("/{blogID}")
-    public ResponseEntity<SResponse> patchBlog(@ApiIgnore @RequestHeader(name = Auth.token) String token,
-                                                       @PathVariable Long blogID,
-                                                       @RequestBody PatchBlogRequest request,
-                                                       BindingResult result) {
+    public ResponseEntity<SResponse> patchBlog(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
+                                               @PathVariable Long blogID,
+                                               @RequestBody PatchBlogRequest request,
+                                               BindingResult result) {
         patchBlogRequestValidator.validate(request, result);
 
         if (result.hasErrors()) {

--- a/src/main/java/com/plogcareers/backend/blog/controller/HomeController.java
+++ b/src/main/java/com/plogcareers/backend/blog/controller/HomeController.java
@@ -38,7 +38,7 @@ public class HomeController {
     )
     @ResponseStatus(value = HttpStatus.CREATED)
     @PostMapping("/subscribes")
-    public ResponseEntity<SResponse> createSubscribe(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> createSubscribe(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                      @Valid @RequestBody CreateSubscribeRequest request,
                                                      BindingResult result) throws BlogNotFoundException {
         if (result.hasErrors()) {
@@ -60,7 +60,7 @@ public class HomeController {
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @DeleteMapping("/subscribes/{subscribeID}")
     public ResponseEntity<SResponse> deleteSubscribe(@PathVariable Long subscribeID,
-                                                     @ApiIgnore @RequestHeader(name = Auth.token) String token
+                                                     @ApiIgnore @RequestHeader(name = Auth.TOKEN) String token
     ) throws BlogNotFoundException {
         Long loginedUserID = authService.getLoginedUserID(token);
         homeService.deleteSubscribe(subscribeID, loginedUserID);
@@ -86,7 +86,7 @@ public class HomeController {
             @ApiResponse(code = 500, message = "서버 에러", response = ErrorResponse.class)}
     )
     @GetMapping("/following-postings")
-    public ResponseEntity<SDataResponse<ListHomePostingsResponse>> listFollowingPostings(@ApiIgnore @RequestHeader(name = Auth.token, required = false) String token,
+    public ResponseEntity<SDataResponse<ListHomePostingsResponse>> listFollowingPostings(@ApiIgnore @RequestHeader(name = Auth.TOKEN, required = false) String token,
                                                                                          ListFollowingPostingsRequest request) {
         Long loginedUserID = authService.getLoginedUserID(token);
         return ResponseEntity.status(HttpStatus.OK).body(new SDataResponse<>(homeService.listFollowingPostings(loginedUserID, request.getSearch(), request.getLastCursorID(), request.getPageSize())));

--- a/src/main/java/com/plogcareers/backend/blog/domain/dto/ListPostingsRequest.java
+++ b/src/main/java/com/plogcareers/backend/blog/domain/dto/ListPostingsRequest.java
@@ -1,6 +1,6 @@
 package com.plogcareers.backend.blog.domain.dto;
 
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 import org.hibernate.validator.constraints.Range;
 
@@ -13,18 +13,18 @@ import java.util.List;
 @Setter
 @Builder
 public class ListPostingsRequest {
-    @ApiParam(value = "검색어")
+    @ApiModelProperty(value = "검색어")
     String search;
-    @ApiParam(value = "검색할 태그 ID 리스트")
+    @ApiModelProperty(value = "검색할 태그 ID 리스트")
     List<Long> tagIDs;
-    @ApiParam(value = "검색할 카테고리 ID")
+    @ApiModelProperty(value = "검색할 카테고리 ID", example = "1")
     Long categoryID;
 
-    @ApiParam(value = "이전 포스팅 리스트의 마지막 포스팅 ID")
+    @ApiModelProperty(value = "이전 포스팅 리스트의 마지막 포스팅 ID", example = "1")
     Long lastCursorID;
 
     @NotNull
     @Range(min = 1, max = 20)
-    @ApiParam(value = "페이지 당 포스팅 수")
+    @ApiModelProperty(value = "페이지 당 포스팅 수", example = "10")
     Long pageSize;
 }

--- a/src/main/java/com/plogcareers/backend/blog/domain/dto/UpdateCategoryRequest.java
+++ b/src/main/java/com/plogcareers/backend/blog/domain/dto/UpdateCategoryRequest.java
@@ -1,35 +1,27 @@
 package com.plogcareers.backend.blog.domain.dto;
 
-import com.plogcareers.backend.blog.domain.entity.Blog;
-import com.plogcareers.backend.blog.domain.entity.Category;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import javax.validation.constraints.NotNull;
-
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class UpdateCategoryRequest {
-    @NotNull
-    @ApiModelProperty(value = "카테고리 ID")
-    private Long id;
+    @ApiModelProperty(hidden = true)
+    private Long blogID;
+    @ApiModelProperty(hidden = true)
+    private Long categoryID;
+    @ApiModelProperty(hidden = true)
+    private Long loginedUserID;
 
-    @NotNull
     @ApiModelProperty(value = "수정할 카테고리 이름")
     private String categoryName;
-    
+
     @ApiModelProperty(value = "수정할 카테고리 설명")
     private String categoryDesc;
-
-    public Category toCategoryEntity(Category category, Blog blog) {
-        category.setCategoryName(this.categoryName);
-        category.setCategoryDesc(this.categoryDesc);
-        category.setBlog(blog);
-        return category;
-    }
 }
+

--- a/src/main/java/com/plogcareers/backend/blog/repository/CategoryRepositortySupport.java
+++ b/src/main/java/com/plogcareers/backend/blog/repository/CategoryRepositortySupport.java
@@ -2,6 +2,7 @@ package com.plogcareers.backend.blog.repository;
 
 import com.plogcareers.backend.blog.domain.entity.Category;
 import com.plogcareers.backend.blog.domain.entity.QCategory;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 import org.springframework.stereotype.Repository;
@@ -19,9 +20,16 @@ public class CategoryRepositortySupport extends QuerydslRepositorySupport {
     }
 
     public Boolean existsDuplicatedCategory(Long blogID, Long categoryID, String categoryName) {
-        Category dupCategory = queryFactory.selectFrom(qCategory)
-                .where(qCategory.blog.id.eq(blogID).and(qCategory.categoryName.eq(categoryName)))
-                .fetchFirst();
+        if (categoryName == null || categoryName.trim().isEmpty()) {
+            return false;
+        }
+        BooleanBuilder where = new BooleanBuilder();
+
+        where.and(qCategory.blog.id.eq(blogID));
+        where.and(qCategory.categoryName.eq(categoryName));
+
+
+        Category dupCategory = queryFactory.selectFrom(qCategory).where(where).fetchFirst();
 
         if (dupCategory == null) {
             return false;
@@ -29,5 +37,4 @@ public class CategoryRepositortySupport extends QuerydslRepositorySupport {
 
         return !dupCategory.getId().equals(categoryID);
     }
-
 }

--- a/src/main/java/com/plogcareers/backend/common/domain/dto/OPagingRequest.java
+++ b/src/main/java/com/plogcareers/backend/common/domain/dto/OPagingRequest.java
@@ -1,6 +1,6 @@
 package com.plogcareers.backend.common.domain.dto;
 
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,11 +13,11 @@ import javax.validation.constraints.Positive;
 @AllArgsConstructor
 @NoArgsConstructor
 public class OPagingRequest {
-    @ApiParam(name = "page", value = "페이지 번호", required = true, example = "1")
+    @ApiModelProperty(name = "page", value = "페이지 번호", required = true, example = "1")
     @Positive
     int page;
 
-    @ApiParam(name = "pageSize", value = "페이지 크기", required = true, example = "10")
+    @ApiModelProperty(name = "pageSize", value = "페이지 크기", required = true, example = "10")
     @Positive
     int pageSize;
 }

--- a/src/main/java/com/plogcareers/backend/common/error/ErrorCode.java
+++ b/src/main/java/com/plogcareers/backend/common/error/ErrorCode.java
@@ -9,8 +9,8 @@ public enum ErrorCode {
     // Blog Domain
     ERR_POST_NOT_FOUND(HttpStatus.NOT_FOUND, "포스트를 찾을 수 없습니다."),
     ERR_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
-    ERR_CATEGORY_DUPLICATED(HttpStatus.BAD_REQUEST, "중복되는 카테고리가 이미 존재합니다."),
-    ERR_CATEGORY_BLOG_MISMATCHED(HttpStatus.BAD_REQUEST, "카테고리와 블로그가 일치하지 않습니다."),
+    ERR_CATEGORY_DUPLICATED(HttpStatus.CONFLICT, "중복되는 카테고리가 이미 존재합니다."),
+    ERR_CATEGORY_BLOG_MISMATCHED(HttpStatus.CONFLICT, "카테고리와 블로그가 일치하지 않습니다."),
     ERR_BLOG_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 블로그입니다."),
     ERR_TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 태그입니다"),
     ERR_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 덧글입니다."),

--- a/src/main/java/com/plogcareers/backend/ums/constant/Auth.java
+++ b/src/main/java/com/plogcareers/backend/ums/constant/Auth.java
@@ -1,5 +1,5 @@
 package com.plogcareers.backend.ums.constant;
 
 public class Auth {
-    public final static String token = "Authorization";
+    public final static String TOKEN = "Authorization";
 }

--- a/src/main/java/com/plogcareers/backend/ums/controller/AuthController.java
+++ b/src/main/java/com/plogcareers/backend/ums/controller/AuthController.java
@@ -131,7 +131,7 @@ public class AuthController {
     })
 
     @PutMapping("/edit-profile")
-    public ResponseEntity<SResponse> updateUserProfile(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> updateUserProfile(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                        @Valid @RequestBody UpdateUserProfileRequest request,
                                                        BindingResult result) {
         if (result.hasErrors()) {
@@ -150,7 +150,7 @@ public class AuthController {
     })
 
     @PutMapping("/edit-password")
-    public ResponseEntity<SResponse> updateUserPassword(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> updateUserPassword(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                                         @Valid @RequestBody UpdateUserPasswordRequest request,
                                                         BindingResult result) {
         if (result.hasErrors()) {
@@ -169,7 +169,7 @@ public class AuthController {
     })
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @PostMapping("/exit-user")
-    public ResponseEntity<SResponse> exitUser(@ApiIgnore @RequestHeader(name = Auth.token) String token,
+    public ResponseEntity<SResponse> exitUser(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token,
                                               @Valid @RequestBody ExitUserRequest request) {
         Long loginedUserID = authService.getLoginedUserID(token);
         authService.exitUser(loginedUserID, request);
@@ -182,7 +182,7 @@ public class AuthController {
             @ApiResponse(code = 401, message = "잘못된 사용자 요청", response = ErrorResponse.class)
     })
     @PostMapping("/refresh-access-token")
-    public ResponseEntity<SResponse> refreshToken(@ApiIgnore @RequestHeader(name = Auth.token) String token) {
+    public ResponseEntity<SResponse> refreshToken(@ApiIgnore @RequestHeader(name = Auth.TOKEN) String token) {
         Long loginedUserID = authService.getLoginedUserID(token);
         RefreshAccessTokenResponse newToken = authService.refreshAccessToken(loginedUserID);
         return ResponseEntity.status(HttpStatus.OK).body(new SDataResponse<>(newToken));

--- a/src/main/java/com/plogcareers/backend/ums/domain/dto/UserJoinRequest.java
+++ b/src/main/java/com/plogcareers/backend/ums/domain/dto/UserJoinRequest.java
@@ -3,7 +3,7 @@ package com.plogcareers.backend.ums.domain.dto;
 import com.plogcareers.backend.blog.domain.entity.Blog;
 import com.plogcareers.backend.ums.domain.entity.User;
 import com.plogcareers.backend.ums.domain.entity.UserRole;
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -28,41 +28,41 @@ enum Sex {
 @Getter
 @NoArgsConstructor
 public class UserJoinRequest {
-    @ApiParam(value = "회원가입 할 이메일")
+    @ApiModelProperty(value = "회원가입 할 이메일")
     @NotNull
     @Email
     private String email;
 
-    @ApiParam(value = "이메일 인증 후 얻은 토큰")
+    @ApiModelProperty(value = "이메일 인증 후 얻은 토큰")
     private String verifyToken;
 
     @NotNull
-    @ApiParam(value = "회원가입 할 비밀번호")
+    @ApiModelProperty(value = "회원가입 할 비밀번호")
     private String password;
 
     @NotNull
     @Length(min = 1, max = 30)
-    @ApiParam(value = "회원가입 할 이름")
+    @ApiModelProperty(value = "회원가입 할 이름")
     private String firstName;
 
     @NotNull
     @Length(min = 1, max = 20)
-    @ApiParam(value = "회원가입 할 성")
+    @ApiModelProperty(value = "회원가입 할 성")
     private String lastName;
 
     @NotNull
     @Length(min = 1, max = 30)
-    @ApiParam(value = "회원가입 할 닉네임")
+    @ApiModelProperty(value = "회원가입 할 닉네임")
     private String nickName;
 
     @NotNull
     @Past
     @DateTimeFormat(pattern = "yyyy-MM-dd")
-    @ApiParam(value = "생년월일")
+    @ApiModelProperty(value = "생년월일")
     private LocalDate birth;
 
     @NotNull
-    @ApiParam(value = "성별", allowableValues = "FEMALE,MALE")
+    @ApiModelProperty(value = "성별", allowableValues = "FEMALE,MALE")
     private Sex sex;
 
 


### PR DESCRIPTION
resolved: #129

# 설명
- Auth.token 상수를 상수 명명 규칙에 맞게 TOKEN으로 변경하였습니다.
- updateCategory를 일부수정 patchCategory로 변경하였습니다.
  - 해당 조건에 맞게 중복 판별 메서드도 변경하였습니다.
- request dto 클래스 내에서 id파라미터가 path variable과 중복 되었는데, 해당 부분의 역할을 구분하였습니다.
  - id -> categoryID 변경
  - categoryID파라미터는 swagger에서 미노출
- 이전 커밋부터 swagger 홈페이지만 가면 생기는 오류를 수정하였습니다.
  - 일부 request dto에서 `@ApiModelProperty` 어노테이션 말고 `@ApiParam`을 써서 생긴 이슈